### PR TITLE
fix: `grep "- "` だとgrepに失敗する

### DIFF
--- a/docs/3_objects/deployment.md
+++ b/docs/3_objects/deployment.md
@@ -48,7 +48,7 @@ DeploymentがReplicaSetを管理し、ReplicaSetがPodを管理しています�
 
 まず、現在のdeploymentのイメージが `nginx:1.16` であることを確認します。
 ```console
-$ kubectl get deploy mynginx -o yaml | grep "- image:"
+$ kubectl get deploy mynginx -o yaml | grep "image:"
       - image: nginx:1.16
 ```
 


### PR DESCRIPTION
grep "- " だと-がoptionと解釈されて構文エラー吐く？
grep " - "だと通ります。

cloud shell内

```shell
$ grep -V
grep (GNU grep) 2.27
Copyright (C) 2016 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Written by Mike Haertel and others, see <http://git.sv.gnu.org/cgit/grep.git/tree/AUTHORS>.

$ echo " - image: hoge" | grep "- "
grep: invalid option -- ' '
Usage: grep [OPTION]... PATTERN [FILE]...
Try 'grep --help' for more information.

$ echo " - image: hoge" | grep " - "
 - image: hoge
```